### PR TITLE
fix: correct HEP timestamps and IPv6 address encoding

### DIFF
--- a/user/event/event_freeswitch.go
+++ b/user/event/event_freeswitch.go
@@ -190,6 +190,7 @@ func (kem *FreeSwitchEvent) GenerateHEP() ([]byte, error) {
 	dstIP := net.IP(dst.IP.Addr[:4])
 
 	date := monotonic.GetRealTime(kem.Timestamp)
+	tsec, tmsec := hepTimestampFields(date)
 
 	hepPacket := hep.Packet{
 		Version:   0x02,
@@ -198,8 +199,8 @@ func (kem *FreeSwitchEvent) GenerateHEP() ([]byte, error) {
 		DstIP:     dstIP,
 		SrcPort:   dst.Port,
 		DstPort:   dst.Port,
-		Tsec:      uint32(date.Unix()),
-		Tmsec:     uint32(date.UnixMilli() - (date.Unix() * 1000)),
+		Tsec:      tsec,
+		Tmsec:     tmsec,
 		ProtoType: 1,
 		Payload:   kem.Data[:kem.DataLen],
 	}

--- a/user/event/event_kamailio.go
+++ b/user/event/event_kamailio.go
@@ -26,7 +26,6 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
-	"net"
 	"rtcagent/model"
 	"rtcagent/outdata/hep"
 	monotonic "rtcagent/user/time"
@@ -177,8 +176,8 @@ func (kem *KamailioEvent) String() string {
 		panic(err)
 	}
 
-	srcIP := net.IP(t.SrcIP.Addr[:4])
-	dstIP := net.IP(t.DstIP.Addr[:4])
+	srcIP := netIPFromAddr(t.SrcIP)
+	dstIP := netIPFromAddr(t.DstIP)
 	addr := fmt.Sprintf("%s:%d", srcIP.String(), t.SrcPort)
 
 	date := monotonic.GetRealTime(kem.Timestamp)
@@ -218,23 +217,12 @@ func (kem *KamailioEvent) GenerateHEP() ([]byte, error) {
 		panic(err)
 	}
 
-	srcIP := net.IP(t.SrcIP.Addr[:4])
-	dstIP := net.IP(t.DstIP.Addr[:4])
+	srcIP := netIPFromAddr(t.SrcIP)
+	dstIP := netIPFromAddr(t.DstIP)
 
 	date := monotonic.GetRealTime(kem.Timestamp)
 
-	hepPacket := hep.Packet{
-		Version:   0x02,
-		Protocol:  22,
-		SrcIP:     srcIP,
-		DstIP:     dstIP,
-		SrcPort:   t.SrcPort,
-		DstPort:   t.DstPort,
-		Tsec:      uint32(date.Unix()),
-		Tmsec:     uint32(date.UnixMilli() - (date.Unix() * 1000)),
-		ProtoType: 1,
-		Payload:   kem.Data[:kem.DataLen],
-	}
+	hepPacket := buildSipHepPacket(hepIPVersion(t.SrcIP), 22, srcIP, dstIP, t.SrcPort, t.DstPort, date, kem.Data[:kem.DataLen])
 
 	return hep.EncodeHEP(&hepPacket)
 

--- a/user/event/event_opensips.go
+++ b/user/event/event_opensips.go
@@ -26,7 +26,6 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
-	"net"
 	"rtcagent/model"
 	"rtcagent/outdata/hep"
 	monotonic "rtcagent/user/time"
@@ -140,8 +139,8 @@ func (kem *OpensipsEvent) String() string {
 		panic(err)
 	}
 
-	srcIP := net.IP(t.SrcIP.Addr[:4])
-	dstIP := net.IP(t.DstIP.Addr[:4])
+	srcIP := netIPFromAddr(t.SrcIP)
+	dstIP := netIPFromAddr(t.DstIP)
 	addr := fmt.Sprintf("%s:%d", srcIP.String(), t.SrcPort)
 
 	date := monotonic.GetRealTime(kem.Timestamp)
@@ -181,23 +180,12 @@ func (kem *OpensipsEvent) GenerateHEP() ([]byte, error) {
 		panic(err)
 	}
 
-	srcIP := net.IP(t.SrcIP.Addr[:4])
-	dstIP := net.IP(t.DstIP.Addr[:4])
+	srcIP := netIPFromAddr(t.SrcIP)
+	dstIP := netIPFromAddr(t.DstIP)
 
 	date := monotonic.GetRealTime(kem.Timestamp)
 
-	hepPacket := hep.Packet{
-		Version:   0x02,
-		Protocol:  22,
-		SrcIP:     srcIP,
-		DstIP:     dstIP,
-		SrcPort:   t.SrcPort,
-		DstPort:   t.DstPort,
-		Tsec:      uint32(date.Unix()),
-		Tmsec:     uint32(date.UnixMilli() - (date.Unix() * 1000)),
-		ProtoType: 1,
-		Payload:   kem.Data[:kem.DataLen],
-	}
+	hepPacket := buildSipHepPacket(hepIPVersion(t.SrcIP), 22, srcIP, dstIP, t.SrcPort, t.DstPort, date, kem.Data[:kem.DataLen])
 
 	return hep.EncodeHEP(&hepPacket)
 

--- a/user/event/hep_helpers.go
+++ b/user/event/hep_helpers.go
@@ -1,0 +1,50 @@
+package event
+
+import (
+	"net"
+	"time"
+
+	"rtcagent/outdata/hep"
+)
+
+const (
+	afINET  = 2
+	afINET6 = 10
+
+	hepFamilyIPv4 = 0x02
+	hepFamilyIPv6 = 0x0a
+)
+
+func netIPFromAddr(addr IpAddr) net.IP {
+	if addr.Len == 16 || addr.Af == afINET6 {
+		return net.IP(addr.Addr[:16])
+	}
+	return net.IP(addr.Addr[:4])
+}
+
+func hepIPVersion(addr IpAddr) byte {
+	if addr.Len == 16 || addr.Af == afINET6 {
+		return hepFamilyIPv6
+	}
+	return hepFamilyIPv4
+}
+
+func hepTimestampFields(t time.Time) (uint32, uint32) {
+	return uint32(t.Unix()), uint32(t.Nanosecond() / 1000)
+}
+
+func buildSipHepPacket(ipVersion byte, protocol byte, src, dst net.IP, srcPort, dstPort uint16, t time.Time, payload []byte) hep.Packet {
+	tsec, tmsec := hepTimestampFields(t)
+	return hep.Packet{
+		Version:   ipVersion,
+		Protocol:  protocol,
+		SrcIP:     src,
+		DstIP:     dst,
+		SrcPort:   srcPort,
+		DstPort:   dstPort,
+		Tsec:      tsec,
+		Tmsec:     tmsec,
+		ProtoType: 1,
+		Payload:   payload,
+	}
+}

--- a/user/event/hep_helpers_test.go
+++ b/user/event/hep_helpers_test.go
@@ -1,0 +1,88 @@
+//go:build !androidgki
+// +build !androidgki
+
+package event
+
+import (
+	"bytes"
+	"encoding/binary"
+	"net"
+	"testing"
+	"time"
+)
+
+func TestHepTimestampFieldsUsesMicroseconds(t *testing.T) {
+	ts := time.Date(2024, 8, 19, 6, 50, 4, 199206453, time.UTC)
+	tsec, tmsec := hepTimestampFields(ts)
+
+	if tsec != uint32(ts.Unix()) {
+		t.Fatalf("unexpected tsec: got %d want %d", tsec, ts.Unix())
+	}
+	if tmsec != 199206 {
+		t.Fatalf("unexpected tmsec: got %d want 199206", tmsec)
+	}
+}
+
+func TestNetIPFromAddrIPv6(t *testing.T) {
+	want := net.ParseIP("2001:db8::1")
+	addr := IpAddr{
+		Af:  afINET6,
+		Len: 16,
+	}
+	copy(addr.Addr[:], want)
+
+	got := netIPFromAddr(addr)
+	if !got.Equal(want) {
+		t.Fatalf("unexpected IPv6: got %s want %s", got, want)
+	}
+	if hepIPVersion(addr) != hepFamilyIPv6 {
+		t.Fatalf("unexpected hep version: got %#x want %#x", hepIPVersion(addr), hepFamilyIPv6)
+	}
+}
+
+func TestKamailioGenerateHEPIPv6(t *testing.T) {
+	ev := &KamailioEvent{
+		DataLen: int32(len("SIP/2.0 200 OK")),
+	}
+	copy(ev.Data[:], "SIP/2.0 200 OK")
+
+	src := net.ParseIP("2001:db8:944::44e6:a8fd:0:453c")
+	dst := net.ParseIP("2001:db8:4a43:d692:287f:e154::318f")
+
+	var rcinfo ReceiveInfo
+	rcinfo.SrcIP.Af = afINET6
+	rcinfo.SrcIP.Len = 16
+	copy(rcinfo.SrcIP.Addr[:], src.To16())
+	rcinfo.DstIP.Af = afINET6
+	rcinfo.DstIP.Len = 16
+	copy(rcinfo.DstIP.Addr[:], dst.To16())
+	rcinfo.SrcPort = 6060
+	rcinfo.DstPort = 49512
+
+	buf := &bytes.Buffer{}
+	if err := binary.Write(buf, binary.LittleEndian, &rcinfo); err != nil {
+		t.Fatalf("write rcinfo: %v", err)
+	}
+	copy(ev.RcInfo[:], buf.Bytes())
+
+	ev.Timestamp = 1445124394701952
+
+	raw, err := ev.GenerateHEP()
+	if err != nil {
+		t.Fatalf("generate hep: %v", err)
+	}
+
+	if len(raw) < 6 || string(raw[:4]) != "HEP3" {
+		t.Fatalf("unexpected hep header: %q", raw[:6])
+	}
+
+	// First chunk after the HEP3 header is the IP family (0x0001).
+	if raw[12] != hepFamilyIPv6 {
+		t.Fatalf("expected IPv6 hep family %#x, got %#x", hepFamilyIPv6, raw[12])
+	}
+
+	chunk5 := []byte{0x00, 0x00, 0x00, 0x05}
+	if !bytes.Contains(raw, chunk5) {
+		t.Fatalf("expected IPv6 source chunk 0x0005 in hep packet")
+	}
+}

--- a/user/time/monotonic.go
+++ b/user/time/monotonic.go
@@ -24,5 +24,5 @@ func GetTime() (uint64, int64) {
 func GetRealTime(capTime uint64) time.Time {
 	monotonic := uint64(C.get_nsecs())
 	timestamp := time.Now().UTC().UnixNano()
-	return time.Unix(0, (timestamp - (int64(monotonic-capTime) * 1000)))
+	return time.Unix(0, timestamp-int64(monotonic-capTime))
 }


### PR DESCRIPTION
## Summary
- Fix monotonic-to-wall-clock conversion: kernel timestamps from `bpf_ktime_get_ns()` are nanoseconds, so remove the erroneous `* 1000` scaling that broke call-flow ordering in HEPIC (#14).
- Encode HEP `Tmsec` in microseconds per the HEP spec instead of milliseconds.
- Read full 16-byte IPv6 addresses from Kamailio/OpenSIPS rcinfo and emit HEP family `0x0a` with IPv6 chunks (#15).

## Test plan
- [x] `go test ./user/event/...`
- [x] `go vet ./...`
- [ ] Run `rtcagent kamailio` against IPv6 SIP traffic and verify src/dst in HEPIC
- [ ] Verify call-flow timestamps in HEPIC match packet order

Fixes #14, #15